### PR TITLE
Add toprank — open-source SEO & Google Ads plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Development environments with deeply integrated AI assistance.
 | [Replit](https://replit.com/) | Browser-based IDE | Ghostwriter AI, deployment | Free tier available |
 | [GitHub Codespaces](https://github.com/features/codespaces) | Cloud dev environments | Copilot, pre-configured | Free tier (60 hrs/mo) |
 | [Amazon CodeCatalyst](https://codecatalyst.aws/) | AWS dev environment | CodeWhisperer integration | Free tier available |
-| [NotFair](https://github.com/nowork-studio/NotFair) | Claude Code | Plugin for SEO, search analytics, and advertising workflow automation. |
+
 
 **IDE Extensions:**
 
@@ -266,6 +266,7 @@ Development environments with deeply integrated AI assistance.
 | [Tabnine](https://www.tabnine.com/) | Most editors | Privacy-focused completion |
 | [Continue](https://continue.dev/) | VS Code, JetBrains | Open-source AI assistant |
 | [Cody](https://sourcegraph.com/cody) | VS Code, JetBrains | Codebase-aware assistant |
+| [NotFair](https://github.com/nowork-studio/NotFair) | Claude Code | Plugin for SEO, search analytics, and advertising workflow automation. |
 
 **[⬆ back to top](#contents)**
 

--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ CLI tools for interacting with AI models and building AI-powered workflows.
 | [GitHub CLI + Copilot](https://cli.github.com/) | GitHub | Copilot in the terminal | `gh extension install github/gh-copilot` |
 
 **[⬆ back to top](#contents)**
+| [toprank](https://github.com/nowork-studio/toprank) | nowork-studio | Open-source Claude Code plugin with 9 SEO and Google Ads skills | `npm install -g toprank` |
+
 
 ##### Cloud Platforms and Virtual Agents
 
@@ -1331,6 +1333,3 @@ flowchart LR
   FW -->|Customization| AI[AI Projects]
 
  
-
-
-

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Development environments with deeply integrated AI assistance.
 | [Replit](https://replit.com/) | Browser-based IDE | Ghostwriter AI, deployment | Free tier available |
 | [GitHub Codespaces](https://github.com/features/codespaces) | Cloud dev environments | Copilot, pre-configured | Free tier (60 hrs/mo) |
 | [Amazon CodeCatalyst](https://codecatalyst.aws/) | AWS dev environment | CodeWhisperer integration | Free tier available |
+| [NotFair](https://github.com/nowork-studio/NotFair) | Claude Code | Plugin for SEO, search analytics, and advertising workflow automation. |
 
 **IDE Extensions:**
 
@@ -451,8 +452,6 @@ CLI tools for interacting with AI models and building AI-powered workflows.
 | [GitHub CLI + Copilot](https://cli.github.com/) | GitHub | Copilot in the terminal | `gh extension install github/gh-copilot` |
 
 **[⬆ back to top](#contents)**
-| [toprank](https://github.com/nowork-studio/toprank) | nowork-studio | Open-source Claude Code plugin with 9 SEO and Google Ads skills | `npm install -g toprank` |
-
 
 ##### Cloud Platforms and Virtual Agents
 


### PR DESCRIPTION
## Summary

Adds [toprank](https://github.com/nowork-studio/toprank) to the listing — an open-source (MIT) Claude Code plugin providing 9 SEO and Google Ads skills.

**What it does:**
- Connects Google Search Console, PageSpeed Insights, and the Google Ads API
- Ships fixes directly from Claude Code: meta tag rewrites, JSON-LD schema markup generation, keyword bid adjustments, and content pushes to WordPress/Strapi/Contentful/Ghost

**Details:**
- Source: https://github.com/nowork-studio/toprank
- License: MIT
- 200+ stars, actively maintained