### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ CLI tools for interacting with AI models and building AI-powered workflows.
 | [PromptFoo](https://github.com/promptfoo/promptfoo) | Prompt testing | CLI-based prompt evaluation and comparison |
 | [Giskard](https://www.giskard.ai/) | ML testing | Bias and robustness testing |
 | [OpenAI Evals](https://github.com/openai/evals) | Eval framework | OpenAI's evaluation framework |
+| [Future AGI](https://github.com/future-agi/future-agi) | Eval and observability | Open-source platform to simulate, evaluate, trace, guardrail, and optimize LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge |
 
 **[⬆ back to top](#contents)**
 
@@ -905,6 +906,7 @@ Structured learning paths and certifications for AI skills.
 | [Weights & Biases](https://wandb.ai/) | ML experiment tracking | Prompts, artifacts, sweeps |
 | [Portkey](https://portkey.ai/) | AI gateway | Observability, routing, fallbacks |
 | [Braintrust](https://www.braintrust.dev/) | Eval and logging platform | Experiments, datasets |
+| [Future AGI](https://github.com/future-agi/future-agi) | Open-source LLM and agent observability | Self-hostable, tracing, 70+ eval metrics, guardrails |
 
 **[⬆ back to top](#contents)**
 

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ CLI tools for interacting with AI models and building AI-powered workflows.
 | [PromptFoo](https://github.com/promptfoo/promptfoo) | Prompt testing | CLI-based prompt evaluation and comparison |
 | [Giskard](https://www.giskard.ai/) | ML testing | Bias and robustness testing |
 | [OpenAI Evals](https://github.com/openai/evals) | Eval framework | OpenAI's evaluation framework |
-| [Future AGI](https://github.com/future-agi/future-agi) | Eval and observability | Open-source platform to simulate, evaluate, trace, guardrail, and optimize LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge |
+| [Future AGI](https://github.com/future-agi/future-agi) | LLM and agent evaluation | Open-source platform for evaluating, tracing, simulating, and improving LLM and AI agent applications. |
 
 **[⬆ back to top](#contents)**
 
@@ -906,7 +906,7 @@ Structured learning paths and certifications for AI skills.
 | [Weights & Biases](https://wandb.ai/) | ML experiment tracking | Prompts, artifacts, sweeps |
 | [Portkey](https://portkey.ai/) | AI gateway | Observability, routing, fallbacks |
 | [Braintrust](https://www.braintrust.dev/) | Eval and logging platform | Experiments, datasets |
-| [Future AGI](https://github.com/future-agi/future-agi) | Open-source LLM and agent observability | Self-hostable, tracing, 70+ eval metrics, guardrails |
+
 
 **[⬆ back to top](#contents)**
 


### PR DESCRIPTION
This PR adds FutureAGI to the Evaluation Frameworks section.

FutureAGI is an open-source platform for evaluating LLM and agent apps. Scores the full agent execution path, not just the final answer. 70+ built-in metrics, multimodal and custom evals, LLM-as-judge, and guardrail scanners behind one evaluate() call. | Apache 2.0 | Self-hostable

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with FutureAGI.