### PR TITLE
Add AI Weekly to Newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Created by [NatNew](https://github.com/natnew) and [Contributors](https://github
 - **Resources**
   - [Articles](#articles)
   - [Newsletters](#newsletters)
+* [AI Weekly](https://aiweekly.co/) - Independent AI news, 3x/week since 2015 for 44,000+ professionals; the few AI stories that matter.
   - [GitHub Repositories](#github-repositories)
   - [Cybersecurity & OSINT](#cybersecurity--osint)
 - [Featured Projects](#featured-projects)


### PR DESCRIPTION
Adds AI Weekly (https://aiweekly.co/) to the Newsletters section. AI Weekly is an independent, solo-edited AI news newsletter publishing 3x/week since 2015 to 44,000+ professionals, surfacing the few AI stories that matter each week. The entry follows the section's existing `* [Name](url) - Description.` format and sits alongside peers like The Batch.